### PR TITLE
Move to dedicated domain checkers.deepomatic.com

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ if config.use_cpp_implementation:
 else:
     import ai
 
-url_prefix = 'https://www.deepomatic.com/checkers/'
+url_prefix = 'https://checkers.deepomatic.com/checkers/'
 
 ###############################################################################
 


### PR DESCRIPTION
Stop using www.deepomatic.com (soon to be deprecated) and switch to dedicated domain checkers.deepomatic.com